### PR TITLE
Add support for mouse events

### DIFF
--- a/example/mouse.cr
+++ b/example/mouse.cr
@@ -1,0 +1,25 @@
+require "../src/ncurses"
+
+NCurses.open do
+  NCurses.cbreak
+  NCurses.noecho
+  NCurses.keypad(true)
+
+  s = "Click around!"
+
+  NCurses.mousemask(NCurses::MouseMask::ALL_MOUSE_EVENTS | NCurses::MouseMask::REPORT_MOUSE_POSITION)
+  NCurses.notimeout(true)
+
+  loop do
+    NCurses.erase
+    NCurses.move(y: 1, x: 2)
+    NCurses.addstr(s)
+    NCurses.refresh
+
+    case key = NCurses.getch
+    when NCurses::KeyCode::MOUSE
+      event = NCurses.getmouse
+      s = "x: #{event.x}, y: #{event.y}, z: #{event.z}, #{event.bstate}"
+    end
+  end
+end

--- a/example/move.cr
+++ b/example/move.cr
@@ -33,4 +33,3 @@ NCurses.open do
     end
   end
 end
-

--- a/example/multibyte.cr
+++ b/example/multibyte.cr
@@ -26,4 +26,3 @@ NCurses.open do
     y = 0 if y >= h
   end
 end
-

--- a/src/ncurses.cr
+++ b/src/ncurses.cr
@@ -4,6 +4,7 @@ module NCurses
   extend self
 
   alias KeyCode = LibNCurses::KeyCode
+  alias MouseMask = LibNCurses::MouseMask
 
   @@stdscr : Window | Nil = nil
 
@@ -75,6 +76,9 @@ module NCurses
   delegate mvhline, mvvline, to: stdscr
   delegate attron, to: stdscr
   delegate bkgd, to: stdscr
+  delegate mousemask, to: stdscr
+  delegate getmouse, to: stdscr
+  delegate mouseinterval, to: stdscr
 
   def longname
     String.new(LibNCurses.longname)
@@ -83,6 +87,4 @@ module NCurses
   def curses_version
     String.new(LibNCurses.curses_version)
   end
-
 end
-

--- a/src/ncurses/attribute.cr
+++ b/src/ncurses/attribute.cr
@@ -25,7 +25,7 @@ module NCurses
   end
 
   def colors
-    (1...LibNCurses.colors).map{ |c| Color.new(c.to_u32) }
+    (1...LibNCurses.colors).map { |c| Color.new(c.to_u32) }
   end
 
   def use_default_colors

--- a/src/ncurses/libncurses.cr
+++ b/src/ncurses/libncurses.cr
@@ -3,6 +3,12 @@ lib LibNCurses
   type Window = Void*
   type Screen = Void*
 
+  struct MEvent
+    id : LibC::Short
+    x, y, z : LibC::Int
+    bstate : MouseMask
+  end
+
   alias Chtype = LibC::UInt
   alias AttrT = Chtype
 
@@ -32,6 +38,52 @@ lib LibNCurses
     ITALIC     = 1_u32 << (23_u32 + ATTR_SHIFT)
   end
 
+  NCURSES_BUTTON_RELEASED = 0o01_u32
+  NCURSES_BUTTON_PRESSED  = 0o02_u32
+  NCURSES_BUTTON_CLICKED  = 0o04_u32
+  NCURSES_DOUBLE_CLICKED  = 0o10_u32
+  NCURSES_TRIPLE_CLICKED  = 0o20_u32
+  NCURSES_RESERVED_EVENT  = 0o40_u32
+
+  @[Flags]
+  enum MouseMask : LibC::UInt
+    BUTTON1_RELEASED       = NCURSES_BUTTON_RELEASED << (0_u32 * 5_u32)
+    BUTTON1_PRESSED        = NCURSES_BUTTON_PRESSED << (0_u32 * 5_u32)
+    BUTTON1_CLICKED        = NCURSES_BUTTON_CLICKED << (0_u32 * 5_u32)
+    BUTTON1_DOUBLE_CLICKED = NCURSES_DOUBLE_CLICKED << (0_u32 * 5_u32)
+    BUTTON1_TRIPLE_CLICKED = NCURSES_TRIPLE_CLICKED << (0_u32 * 5_u32)
+
+    BUTTON2_RELEASED       = NCURSES_BUTTON_RELEASED << (1_u32 * 5_u32)
+    BUTTON2_PRESSED        = NCURSES_BUTTON_PRESSED << (1_u32 * 5_u32)
+    BUTTON2_CLICKED        = NCURSES_BUTTON_CLICKED << (1_u32 * 5_u32)
+    BUTTON2_DOUBLE_CLICKED = NCURSES_DOUBLE_CLICKED << (1_u32 * 5_u32)
+    BUTTON2_TRIPLE_CLICKED = NCURSES_TRIPLE_CLICKED << (1_u32 * 5_u32)
+
+    BUTTON3_RELEASED       = NCURSES_BUTTON_RELEASED << (2_u32 * 5_u32)
+    BUTTON3_PRESSED        = NCURSES_BUTTON_PRESSED << (2_u32 * 5_u32)
+    BUTTON3_CLICKED        = NCURSES_BUTTON_CLICKED << (2_u32 * 5_u32)
+    BUTTON3_DOUBLE_CLICKED = NCURSES_DOUBLE_CLICKED << (2_u32 * 5_u32)
+    BUTTON3_TRIPLE_CLICKED = NCURSES_TRIPLE_CLICKED << (2_u32 * 5_u32)
+
+    BUTTON4_RELEASED       = NCURSES_BUTTON_RELEASED << (3_u32 * 5_u32)
+    BUTTON4_PRESSED        = NCURSES_BUTTON_PRESSED << (3_u32 * 5_u32)
+    BUTTON4_CLICKED        = NCURSES_BUTTON_CLICKED << (3_u32 * 5_u32)
+    BUTTON4_DOUBLE_CLICKED = NCURSES_DOUBLE_CLICKED << (3_u32 * 5_u32)
+    BUTTON4_TRIPLE_CLICKED = NCURSES_TRIPLE_CLICKED << (3_u32 * 5_u32)
+
+    BUTTON5_RELEASED       = NCURSES_BUTTON_RELEASED << (4_u32 * 5_u32)
+    BUTTON5_PRESSED        = NCURSES_BUTTON_PRESSED << (4_u32 * 5_u32)
+    BUTTON5_CLICKED        = NCURSES_BUTTON_CLICKED << (4_u32 * 5_u32)
+    BUTTON5_DOUBLE_CLICKED = NCURSES_DOUBLE_CLICKED << (4_u32 * 5_u32)
+    BUTTON5_TRIPLE_CLICKED = NCURSES_TRIPLE_CLICKED << (4_u32 * 5_u32)
+
+    BUTTON_CTRL           = 0o01_u32 << (5_u32 * 5_u32)
+    BUTTON_SHIFT          = 0o02_u32 << (5_u32 * 5_u32)
+    BUTTON_ALT            = 0o04_u32 << (5_u32 * 5_u32)
+    REPORT_MOUSE_POSITION = 0o10_u32 << (5_u32 * 5_u32)
+    ALL_MOUSE_EVENTS      = REPORT_MOUSE_POSITION - 1_u32
+  end
+
   enum Color : Chtype
     BLACK   = 0
     RED     = 1
@@ -49,8 +101,8 @@ lib LibNCurses
   end
 
   enum KeyCode : LibC::Int
-    ESC = 27
-    RETURN = 10
+    ESC       =    27
+    RETURN    =    10
     CODE_YES  = 0o400
     MIN       = 0o401
     BREAK     = 0o401
@@ -234,6 +286,12 @@ lib LibNCurses
   fun wattroff(w : Window, attr : LibC::Int) : Result
   fun wattrset(w : Window, attr : LibC::Int) : Result
   fun use_default_colors : Result
+
+  # Mouse
+  fun has_mouse : Bool
+  fun getmouse(e : MEvent*) : LibC::Int
+  fun mousemask(newmask : MouseMask, oldmask : MouseMask*) : MouseMask
+  fun mouseinterval(interval : LibC::Int) : LibC::Int
 
   # misc
   fun longname : Pointer(LibC::Char)

--- a/src/ncurses/raw_window.cr
+++ b/src/ncurses/raw_window.cr
@@ -155,11 +155,25 @@ module NCurses
     end
 
     def maxyx
-      { maxy, maxx }
+      {maxy, maxx}
     end
 
     def resize(height, width)
       check_error(LibNCurses.wresize(raw_win, height, width), "wresize")
+    end
+
+    def mousemask(newmask : MouseMask, oldmask : MouseMask? = nil)
+      mask = oldmask || MouseMask.new(0)
+      check_error(LibNCurses.mousemask(newmask, pointerof(mask)), "mousemask")
+    end
+
+    def getmouse
+      check_error(LibNCurses.getmouse(out event), "getmouse")
+      event
+    end
+
+    def mouseinterval(interval : Int32)
+      check_error(LibNCurses.mouseinterval(interval), "mouseinterval")
     end
   end
 end


### PR DESCRIPTION
Fairly simple addition. Added `example/mouse.cr` and ran `crystal tool format`.